### PR TITLE
delete unnecessary reset liveFrame logic at playend

### DIFF
--- a/packages/ss6player-pixi/src/SS6Player.ts
+++ b/packages/ss6player-pixi/src/SS6Player.ts
@@ -192,7 +192,6 @@ export class SS6Player extends PIXI.Container {
             }
             if (this._loops === 0) this.isPlaying = false;
           }
-          this.resetLiveFrame();
         }
         // speed -
         if (this._currentFrame < this._startFrame) {


### PR DESCRIPTION
再生終了後に liveFrame をクリアしていた処理を削除しました