### PR TITLE
update license

### DIFF
--- a/ThirdPartyLicenses.md
+++ b/ThirdPartyLicenses.md
@@ -1,6 +1,5 @@
 |Licensed Code  |License Type  |Licenser URL  |
 |---|---|---|
-|PixiJS  |MIT  |https://github.com/pixijs/pixi.js  |
 |FlatBuffers  |Apache License v2.0  |https://github.com/google/flatbuffers/  |
 
-Notice: The license type above may differ from the latest one. (updated at 2018/11/21)
+Notice: The license type above may differ from the latest one. (updated at 2020/10/07)

--- a/packages/ss6player-pixi/README.md
+++ b/packages/ss6player-pixi/README.md
@@ -10,6 +10,12 @@
 
 リリース最新版のデモは [こちら](https://spritestudio.github.io/SS6PlayerForWeb/Player/index.html) になります。
 
+## ライセンス
+ss6player-pixi のライセンスは [LISENCE](../../LICENSE) となります。
+
+ss6player-pixi は依存ライブラリの [FlatBuffers](https://google.github.io/flatbuffers/) と [ssfblib](../ssfblib) をバンドルしています。
+ForWeb のコンポーネントが依存しているサードパーティライブラリのライセンスは [ThirdPartyLicenses.md](../../ThirdPartyLicenses.md) を参照してください。
+
 ## アニメーションデータの作成方法
 
 SpriteStudio 6 のプロジェクトファイル sspj からアニメーションデータファイル ssfb ファイルをコンバートします。 コンバートには Ss6Converter を利用します。

--- a/packages/ss6player-rpgmakermz/README.md
+++ b/packages/ss6player-rpgmakermz/README.md
@@ -10,6 +10,12 @@
 
 リリース最新版のデモは [こちら](https://spritestudio.github.io/SS6PlayerForWeb/mz/SampleProject/index.html) になります。
 
+## ライセンス
+ss6player-rpgmakermz のライセンスは [LISENCE](../../LICENSE) となります。
+
+ss6player-rpgmakermz は依存ライブラリの [FlatBuffers](https://google.github.io/flatbuffers/) と [ssfblib](../ssfblib) と [ss6player-pixi](../ss6player-pixi) をバンドルしています。
+ForWeb のコンポーネントが依存しているサードパーティライブラリのライセンスは [ThirdPartyLicenses.md](../../ThirdPartyLicenses.md) を参照してください。
+
 # アニメーションデータの作成方法
 
 SpriteStudio 6 のプロジェクトファイル sspj からアニメーションデータファイル ssfb ファイルをコンバートします。 コンバートには Ss6Converter を利用します。

--- a/packages/ssfblib/README.md
+++ b/packages/ssfblib/README.md
@@ -10,7 +10,7 @@ ssfblib の schema ファイルは SpriteStudio6-SDK に同封しています。
 [こちらを参照してください](https://github.com/SpriteStudio/SpriteStudio6-SDK/blob/develop/Build/Converter/fbs/ssfb.fbs)
 
 ## ライセンス
-ssfb のライセンスは [LISENCE](../../LICENSE) となります。 
+ssfblib のライセンスは [LISENCE](../../LICENSE) となります。 
 
 ## 使い方
 ### API リファレンス

--- a/packages/ssfblib/README.md
+++ b/packages/ssfblib/README.md
@@ -9,6 +9,9 @@ ssfblib は [FlatBuffers](https://google.github.io/flatbuffers/) が schema か�
 ssfblib の schema ファイルは SpriteStudio6-SDK に同封しています。
 [こちらを参照してください](https://github.com/SpriteStudio/SpriteStudio6-SDK/blob/develop/Build/Converter/fbs/ssfb.fbs)
 
+## ライセンス
+ssfb のライセンスは [LISENCE](../../LICENSE) となります。 
+
 ## 使い方
 ### API リファレンス
 


### PR DESCRIPTION
- サードパーティライブラリ一覧から pixi.js を削除しました。(バンドルしていないので)
- 各コンポーネントの README.md にライセンスの表記を記載しました。
