### PR TITLE
[ss6player-pixi] improve update logic. enable frame skip at default

### DIFF
--- a/packages/ss6player-pixi/src/SS6Player.ts
+++ b/packages/ss6player-pixi/src/SS6Player.ts
@@ -225,7 +225,7 @@ export class SS6Player extends PIXI.Container {
               }
               incFrameNo = this._startFrame;
             }
-            currentFrameNo = incFrameNo
+            currentFrameNo = incFrameNo;
             // Check User Data
             if (this._isPlaying) {
               if (this.HaveUserData(currentFrameNo)) {

--- a/packages/ss6player-pixi/src/SS6Player.ts
+++ b/packages/ss6player-pixi/src/SS6Player.ts
@@ -864,7 +864,6 @@ export class SS6Player extends PIXI.Container {
       let mesh: any = this.prevMesh[i];
       const part: ss.ssfb.PartData = this.fbObj.animePacks(this.parts).parts(i);
       const partType = part.type();
-      const partName = part.name();
       let overWrite: boolean = (this.substituteOverWrite[i] !== null) ? this.substituteOverWrite[i] : false;
       let overWritekeyParam: SS6PlayerInstanceKeyParam = this.substituteKeyParam[i];
 
@@ -873,7 +872,7 @@ export class SS6Player extends PIXI.Container {
         case ss.ssfb.SsPartType.Instance:
           if (mesh == null) {
             mesh = this.MakeCellPlayer(part.refname());
-            mesh.name = partName;
+            mesh.name = part.name();
           }
           break;
         case ss.ssfb.SsPartType.Normal:
@@ -881,14 +880,14 @@ export class SS6Player extends PIXI.Container {
           if (cellID >= 0 && this.prevCellID[i] !== cellID) {
             if (mesh != null) mesh.destroy();
             mesh = this.MakeCellMesh(cellID); // (cellID, i)?
-            mesh.name = partName;
+            mesh.name = part.name();
           }
           break;
         case ss.ssfb.SsPartType.Mesh:
           if (cellID >= 0 && this.prevCellID[i] !== cellID) {
             if (mesh != null) mesh.destroy();
             mesh = this.MakeMeshCellMesh(i, cellID); // (cellID, i)?
-            mesh.name = partName;
+            mesh.name = part.name();
           }
           break;
         case ss.ssfb.SsPartType.Nulltype:
@@ -896,7 +895,7 @@ export class SS6Player extends PIXI.Container {
           if (this.prevCellID[i] !== cellID) {
             if (mesh != null) mesh.destroy();
             mesh = new PIXI.Container();
-            mesh.name = partName;
+            mesh.name = part.name();
           }
           break;
         default:
@@ -904,7 +903,7 @@ export class SS6Player extends PIXI.Container {
             // 小西 - デストロイ処理
             if (mesh != null) mesh.destroy();
             mesh = this.MakeCellMesh(cellID); // (cellID, i)?
-            mesh.name = partName;
+            mesh.name = part.name();
           }
           break;
       }
@@ -1097,7 +1096,6 @@ export class SS6Player extends PIXI.Container {
             verts[0] = vec2[0];
             verts[1] = vec2[1];
           }
-          mesh.drawMode = PIXI.DRAW_MODES.TRIANGLES;
 
           const px = verts[0];
           const py = verts[1];
@@ -1517,7 +1515,7 @@ export class SS6Player extends PIXI.Container {
     const verts = new Float32Array([0, 0, -w, -h, w, -h, -w, h, w, h]);
     const uvs = new Float32Array([(u1 + u2) / 2, (v1 + v2) / 2, u1, v1, u2, v1, u1, v2, u2, v2]);
     const indices = new Uint16Array([0, 1, 2, 0, 2, 4, 0, 4, 3, 0, 1, 3]); // ??? why ???
-    const mesh = new PIXI.SimpleMesh(this.resources[cell.cellMap().name()].texture, verts, uvs, indices);
+    const mesh = new PIXI.SimpleMesh(this.resources[cell.cellMap().name()].texture, verts, uvs, indices, PIXI.DRAW_MODES.TRIANGLES);
     return mesh;
   }
 
@@ -1551,7 +1549,7 @@ export class SS6Player extends PIXI.Container {
 
       const verts = new Float32Array(num * 2); // Zは必要ない？
 
-      const mesh = new PIXI.SimpleMesh(this.resources[this.fbObj.cells(cellID).cellMap().name()].texture, verts, uvs, indices);
+      const mesh = new PIXI.SimpleMesh(this.resources[this.fbObj.cells(cellID).cellMap().name()].texture, verts, uvs, indices, PIXI.DRAW_MODES.TRIANGLES);
       return mesh;
     }
 


### PR DESCRIPTION
- change frameskip property default value is as `true`.
- change to use PIXI.Ticker `elapsedMS` property at calculating delta time of Update function.
- fix instance parts bug that when a parent part plays to the end of the frame number,  children instance part is reset from currently playing frame number to start frame number.

---

- フレームスキップをデフォルト true にしました。
- `Update` 関数の差分時間を自身で計算していたものを PIXI.Ticker のプロパティを利用するように変更しました。
- インスタンスパーツの独立再生時にアニメーションデータの最終フレーム数に到達すると、インスタンスパーツの再生フレーム数がリセットされる問題を修正しました。