### PR TITLE
bugfix ss6player-viewer

### DIFF
--- a/docs/Player/index.html
+++ b/docs/Player/index.html
@@ -6,7 +6,7 @@
 </head>
 <body>
   <!-- pixi.jsの読込 -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/5.3.4/pixi.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/5.3.8/pixi.min.js"></script>
   <!-- ss6player -->
   <script src="./ss6player-pixi.umd.js"></script>
   <!-- ユーザープログラムの読込 -->

--- a/docs/ViewerPlayer/player.html
+++ b/docs/ViewerPlayer/player.html
@@ -10,7 +10,7 @@
   <meta http-equiv=”Cache-Control” content=”no-cache”>
   <title>SpriteStudio Web Player</title>
   <!-- pixi.jsの読込 -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/5.3.4/pixi.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/5.3.8/pixi.min.js"></script>
   <script src="./ss6player-viewer.umd.js"></script>
   <link rel="stylesheet" href="./player.css">
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12597,7 +12597,7 @@
       "license": "SEE LICENSE",
       "dependencies": {
         "flatbuffers": "^1.12.0",
-        "pixi.js": "^5.2.5",
+        "pixi.js": "^5.3.8",
         "ssfblib": "^1.0.1"
       },
       "devDependencies": {
@@ -13065,7 +13065,7 @@
       "version": "0.5.0",
       "license": "SEE LICENSE",
       "dependencies": {
-        "pixi.js": "^5.2.5",
+        "pixi.js": "^5.3.8",
         "ss6player-pixi": "^1.5.0"
       },
       "devDependencies": {
@@ -13536,7 +13536,7 @@
       "license": "SEE LICENSE",
       "dependencies": {
         "jszip": "^3.6.0",
-        "pixi.js": "^5.2.5",
+        "pixi.js": "^5.3.8",
         "ss6player-pixi": "^1.5.0",
         "ssfblib": "1.0.1"
       },
@@ -22688,7 +22688,7 @@
         "http-server": "^0.12.3",
         "lodash.camelcase": "^4.3.0",
         "opener": "^1.5.2",
-        "pixi.js": "^5.2.5",
+        "pixi.js": "^5.3.8",
         "rimraf": "^3.0.2",
         "rollup": "^2.41.4",
         "rollup-plugin-commonjs": "^10.1.0",
@@ -23135,7 +23135,7 @@
         "http-server": "^0.12.3",
         "lodash.camelcase": "^4.3.0",
         "opener": "^1.5.2",
-        "pixi.js": "^5.2.5",
+        "pixi.js": "^5.3.8",
         "replace": "^1.2.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.41.4",
@@ -23584,7 +23584,7 @@
         "jszip": "^3.6.0",
         "lodash.camelcase": "^4.3.0",
         "opener": "^1.5.2",
-        "pixi.js": "^5.2.5",
+        "pixi.js": "^5.3.8",
         "replace": "^1.2.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.41.4",

--- a/packages/ss6player-pixi/package-lock.json
+++ b/packages/ss6player-pixi/package-lock.json
@@ -9,7 +9,7 @@
 			"license": "SEE LICENSE",
 			"dependencies": {
 				"flatbuffers": "^1.12.0",
-				"pixi.js": "^5.2.5"
+				"pixi.js": "^5.3.8"
 			},
 			"devDependencies": {
 				"@types/flatbuffers": "^1.10.0",

--- a/packages/ss6player-pixi/package.json
+++ b/packages/ss6player-pixi/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "flatbuffers": "^1.12.0",
-    "pixi.js": "^5.2.5",
+    "pixi.js": "^5.3.8",
     "ssfblib": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/ss6player-pixi/src/SS6Player.ts
+++ b/packages/ss6player-pixi/src/SS6Player.ts
@@ -194,11 +194,15 @@ export class SS6Player extends PIXI.Container {
     this.defaultFrameMap = [];
   }
 
+  protected Update(delta: number): void {
+    this.UPdateInternal(delta);
+  }
+
   /**
    * Update is called PIXI.ticker
    * @param {number} delta - expected 1
    */
-  protected Update(delta: number): void {
+  protected UPdateInternal(delta: number, rewindAfterReachingEndFrame: boolean = true): void {
     const elapsedTime = PIXI.Ticker.shared.elapsedMS;
     const toNextFrame = this._isPlaying && !this._isPausing;
     if (toNextFrame && this.updateInterval !== 0) {
@@ -220,14 +224,21 @@ export class SS6Player extends PIXI.Container {
             if (incFrameNo > this._endFrame) {
               if (this._loops === -1) {
                 // infinite loop
+                incFrameNo = this._startFrame;
               } else {
                 this._loops--;
                 if (this.playEndCallback !== null) {
                   this.playEndCallback(this);
                 }
-                if (this._loops === 0) this._isPlaying = false;
+                if (this._loops === 0) {
+                  this._isPlaying = false;
+                  // stop playing the animation
+                  incFrameNo = (rewindAfterReachingEndFrame) ? this._endFrame : this._endFrame;
+                } else {
+                  // continue to play the animation
+                  incFrameNo = this._startFrame;
+                }
               }
-              incFrameNo = this._startFrame;
             }
             currentFrameNo = incFrameNo;
             // Check User Data
@@ -247,14 +258,19 @@ export class SS6Player extends PIXI.Container {
             if (decFrameNo < this._startFrame) {
               if (this._loops === -1) {
                 // infinite loop
+                decFrameNo = this._endFrame;
               } else {
                 this._loops--;
                 if (this.playEndCallback !== null) {
                   this.playEndCallback(this);
                 }
-                if (this._loops === 0) this._isPlaying = false;
+                if (this._loops === 0) {
+                  this._isPlaying = false;
+                  decFrameNo = (rewindAfterReachingEndFrame) ? this._endFrame : this._startFrame;
+                } else {
+                  decFrameNo = this._endFrame;
+                }
               }
-              decFrameNo = this._endFrame;
             }
             currentFrameNo = decFrameNo;
             // Check User Data

--- a/packages/ss6player-rpgmakermz/package-lock.json
+++ b/packages/ss6player-rpgmakermz/package-lock.json
@@ -8,7 +8,7 @@
 			"version": "0.5.0",
 			"license": "SEE LICENSE",
 			"dependencies": {
-				"pixi.js": "^5.2.5"
+				"pixi.js": "^5.3.8"
 			},
 			"devDependencies": {
 				"concurrently": "^6.0.0",

--- a/packages/ss6player-rpgmakermz/package.json
+++ b/packages/ss6player-rpgmakermz/package.json
@@ -43,7 +43,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "pixi.js": "^5.2.5",
+    "pixi.js": "^5.3.8",
     "ss6player-pixi": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/ss6player-viewer/package-lock.json
+++ b/packages/ss6player-viewer/package-lock.json
@@ -9,7 +9,7 @@
 			"license": "SEE LICENSE",
 			"dependencies": {
 				"jszip": "^3.6.0",
-				"pixi.js": "^5.2.5"
+				"pixi.js": "^5.3.8"
 			},
 			"devDependencies": {
 				"concurrently": "^6.0.0",

--- a/packages/ss6player-viewer/package.json
+++ b/packages/ss6player-viewer/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "ss6player-pixi": "^1.5.0",
     "ssfblib": "1.0.1",
-    "pixi.js": "^5.2.5",
+    "pixi.js": "^5.3.8",
     "jszip": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/ss6player-viewer/src/AnimationContainer.ts
+++ b/packages/ss6player-viewer/src/AnimationContainer.ts
@@ -118,7 +118,7 @@ export class AnimationContainer extends SS6Player {
   }
 
   protected Update(delta: number) {
-    super.Update(delta);
+    this.UPdateInternal(delta);
     // 毎回実行されるコールバック
     if (this.isPlaying && !this.isPausing) {
       if (this.onUpdateCallback !== null) {

--- a/packages/ss6player-viewer/src/AnimationContainer.ts
+++ b/packages/ss6player-viewer/src/AnimationContainer.ts
@@ -97,6 +97,8 @@ export class AnimationContainer extends SS6Player {
   }
 
   public Play() {
+    this.loop = (this.ssWebPlayer.infinityFlag) ? -1 : 1; // Change loop status at before playing an animation.
+
     super.Play();
     if (this.onPlayStateChangeCallback !== null) {
       this.onPlayStateChangeCallback(this.isPlaying, this.isPausing);

--- a/packages/ss6player-viewer/src/AnimationContainer.ts
+++ b/packages/ss6player-viewer/src/AnimationContainer.ts
@@ -7,14 +7,6 @@ import { Player } from './Player';
 export class AnimationContainer extends SS6Player {
   private readonly ssWebPlayer: Player;
 
-  private get _playEndCallback() {
-    return this.ssWebPlayer.playEndCallback;
-  }
-
-  private get _onUserDataCallback() {
-    return this.ssWebPlayer.onUserDataCallback;
-  }
-
   private get onUpdateCallback() {
     return this.ssWebPlayer.onUpdateCallback;
   }
@@ -31,6 +23,19 @@ export class AnimationContainer extends SS6Player {
 
   public Setup(animePackName: string, animeName: string) {
     super.Setup(animePackName, animeName);
+
+    let self: AnimationContainer = this;
+    this.playEndCallback = (player: SS6Player) => {
+      if (self.ssWebPlayer && self.ssWebPlayer.playEndCallback) {
+        self.ssWebPlayer.playEndCallback(self);
+      }
+    };
+
+    this.onUserDataCallback = (data: any) => {
+      if (self.ssWebPlayer && self.ssWebPlayer.onUpdateCallback) {
+        self.ssWebPlayer.onUpdateCallback(self);
+      }
+    };
 
     // アニメーションの FrameDataMap を準備する
     this.setupCurrentAnimationFrameDataMap();

--- a/packages/ss6player-viewer/src/Player.ts
+++ b/packages/ss6player-viewer/src/Player.ts
@@ -15,6 +15,8 @@ export class Player {
 
   private animePackMap: { [key: string]: any; } = null;
 
+  public infinityFlag: boolean = true;
+
   public getAnimePackMap() {
     return this.animePackMap;
   }
@@ -248,7 +250,8 @@ export class Player {
   }
 
   public switchLoop(isInfinity: boolean) {
-    this.textureContainer.loop = (isInfinity) ? -1 : 1;
+    this.textureContainer.loop = (isInfinity) ? -1 : 1; // Changing loop status at being playing an animation.
+    this.infinityFlag = isInfinity;
   }
 
   public setAnimationSection(_startframe: number = -1, _endframe: number = -1, _loops: number = -1) {


### PR DESCRIPTION
- Update pixi.js that  ss6player depends on to 5.3.8.
- Fix a bug that does not invoke PlayEndCallback and onUpdateCallback on ss6player-viewer.
- Display end frame animation at finishing playing an animation on ss6player-viewer.
- On ss6player-viewer, Keep a loop status that selects infinite loop or playing at once.
